### PR TITLE
Chore/Move enums

### DIFF
--- a/server/app/enums/__init__.py
+++ b/server/app/enums/__init__.py
@@ -1,0 +1,10 @@
+from app.enums.clothes import (
+    CategoryEnum,
+    SizeEnum,
+    StatusEnum,
+    StyleEnum,
+    SeasonEnum,
+    NoteEnum,
+    ColorEnum,
+    MaterialsEnum
+)

--- a/server/app/enums/clothes.py
+++ b/server/app/enums/clothes.py
@@ -1,0 +1,93 @@
+from enum import Enum
+
+class CategoryEnum(str, Enum):
+    tops = "Tops"
+    shirts = "Chemises"
+    blouses = "Blouses"
+    trousers = "Pantalons"
+    skirts = "Jupes"
+    shorts = "Shorts"
+    dress = "Robes"
+    jacket = "Vestes"
+    coat = "Manteaux"
+    trench = "Trenchs"
+    sweater = "Pulls"
+    cardigan = "Cardigans"
+    body = "Body"
+    tshirt = "T-shirt"
+    blazer = "Blazers"
+    vest = "Gilet"
+    headwear = "Couvre-chef"
+    shoes = "Chaussures"
+    bags = "Sacs"
+    underwear = "Sous-vêtements"
+    accessories = "Accessoires"
+    swimwear = "Maillots de bains"
+
+class SizeEnum(str, Enum):
+    XS = "XS"
+    S = "S"
+    M = "M"
+    L = "L"
+    XL = "XL"
+    XXL = "XXL"
+    XXXL = "3XL"
+    XXXXL = "4XL"
+
+class StatusEnum(str, Enum):
+    clean = "Propre"
+    dirty = "Sale"
+
+class StyleEnum(str, Enum):
+    boheme = "Bohème"
+    vintage = "Vintage"
+    classique = "Classique"
+    casual = "Casual"
+    streetwear = "Streetwear"
+    chic = "Chic"
+
+class SeasonEnum(str, Enum):
+    spring = "Printemps"
+    summer = "Été"
+    autumn = "Automne"
+    winter = "Hiver"
+
+class NoteEnum(int, Enum):
+    one = 1
+    two = 2
+    three = 3
+    four = 4
+    five = 5
+    six = 6
+    seven = 7
+    eight = 8
+    nine = 9
+    ten = 10
+
+class ColorEnum(str, Enum):
+    black = "Noir"
+    white = "Blanc"
+    grey = "Gris"
+    beige = "Beige"
+    pink = "Rose"
+    purple = "Violet"
+    blue = "Bleu"
+    green = "Vert"
+    orange = "Orange"
+    red = "Rouge"
+    yellow = "Jaune"
+    brown = "Marron"
+
+class MaterialsEnum(str, Enum):
+    cotton = "Coton"
+    linen = "Lin"
+    leather = "Cuir"
+    wool = "Laine"
+    viscose = "Viscose"
+    spandex = "Élasthanne"
+    polyester = "Polyester"
+    lyocell = "Lyocell"
+    silk = "Soie"
+    cashmere = "Cachemire"
+    acrylic = "Acrylique"
+    polyamide = "Polyamide"

--- a/server/app/models/clothes.py
+++ b/server/app/models/clothes.py
@@ -1,110 +1,19 @@
-from enum import Enum
 from sqlmodel import SQLModel, Field
-from datetime import datetime 
+from datetime import datetime
+from app.enums import (
+      CategoryEnum,
+      SizeEnum,
+      StatusEnum,
+      StyleEnum,
+      SeasonEnum,
+      NoteEnum,
+      ColorEnum,
+      MaterialsEnum,
+)
 
 # ============================================
 # PYDANTIC SCHEMAS (Models)
 # ============================================
-
-class CategoryEnum(str, Enum):
-    tops = "Tops"
-    shirts = "Chemises"
-    blouses = "Blouses"
-    trousers = "Pantalons"
-    skirts = "Jupes"
-    shorts = "Shorts"
-    dress = "Robes"
-    jacket = "Vestes"
-    coat = "Manteaux"
-    trench = "Trenchs"
-    sweater = "Pulls"
-    cardigan = "Cardigans"
-    body = "Body"
-    tshirt = "T-shirt"
-    blazer = "Blazers"
-    vest = "Gilet"
-    headwear = "Couvre-chef"
-    shoes = "Chaussures"
-    bags = "Sacs"
-    underwear = "Sous-vêtements"
-    accessories = "Accessoires"
-    swimwear = "Maillots de bains"
-
-
-class SizeEnum(str, Enum):
-    XS = "XS"
-    S = "S"
-    M = "M"
-    L = "L"
-    XL = "XL"
-    XXL = "XXL"
-    XXXL = "3XL"
-    XXXXL = "4XL"
-
-
-class StatusEnum(str, Enum):
-    clean = "Propre"
-    dirty = "Sale"
-
-
-class StyleEnum(str, Enum):
-    boheme = "Bohème"
-    vintage = "Vintage"
-    classique = "Classique"
-    casual = "Casual"
-    streetwear = "Streetwear"
-    chic = "Chic"
-
-
-class SeasonEnum(str, Enum):
-    spring = "Printemps"
-    summer = "Été"
-    autumn  = "Automne"
-    winter  = "Hiver"
-
-
-class NoteEnum(int, Enum):
-    one = 1
-    two = 2
-    three = 3
-    four = 4
-    five = 5
-    six = 6
-    seven = 7
-    eight = 8
-    nine = 9
-    ten = 10
-
-
-class ColorEnum(str, Enum):
-    black = "Noir"
-    white = "Blanc"
-    grey = "Gris"
-    beige = "Beige"
-    pink = "Rose"
-    purple = "Violet"
-    blue = "Bleu"
-    green = "Vert"
-    orange = "Orange"
-    red = "Rouge"
-    yellow = "Jaune"
-    brown = "Marron"
-
-
-class MaterialsEnum(str, Enum):
-    cotton = "Coton"
-    linen = "Lin"
-    leather = "Cuir"
-    wool = "Laine"
-    viscose = "Viscose"
-    spandex = "Élasthanne"
-    polyester = "Polyester"
-    lyocell = "Lyocell"
-    silk = "Soie"
-    cashmere = "Cachemire"
-    acrylic = "Acrylique"
-    polyamide = "Polyamide"
-    
 
 class ClotheCreate(SQLModel):
     created_at : datetime = Field(default_factory=datetime.now)


### PR DESCRIPTION
Sous les conseils de Laïla, afin de pouvoir réutiliser les enums plus facilement et garder les modèles le plus "propre" possible. Il s'agit de passer les enums en classe afin de les utiliser en les important dans nos modèles.

On les a mis dans un fichier dans un dossier enum : 
- import par le fichier init
- tous les enums pour le modèle Clothes dans `enums/clothes.py` 