### PR TITLE
Changes to remove a conflict between SQLModel and Alembic

### DIFF
--- a/server/app/db/database.py
+++ b/server/app/db/database.py
@@ -1,6 +1,6 @@
 from dotenv import load_dotenv
 import os
-from sqlmodel import SQLModel, create_engine, Session
+from sqlmodel import create_engine, Session
 
 load_dotenv()
 
@@ -10,10 +10,6 @@ DATABASE_LOCAL = os.getenv('DATABASE_LOCAL')
 
 if ENV == 'dev':
     engine = create_engine(DATABASE_LOCAL, echo=True)
-
-    # Function to create database tables from SQLModel classes
-    def create_db_and_tables():
-        SQLModel.metadata.create_all(engine)
 
 elif ENV == 'prod':
     engine = create_engine(DATABASE_URL_PROD, echo=True)

--- a/server/main.py
+++ b/server/main.py
@@ -3,15 +3,10 @@ from app.routers.clothes_router import router as clothes_router
 from app.routers.tags_router import router as tags_router 
 from app.routers.tags_clothes_router import router as tags_clothes_router
 from contextlib import asynccontextmanager
-from app.db.database import ENV
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     print("Startup")
-    if ENV == 'dev':
-        from app.db.database import create_db_and_tables
-        create_db_and_tables()
-        print('Tables created in local database')
     yield
     print("Shutdown")
 


### PR DESCRIPTION
On a découvert qu'il pouvait y avoir un conflit entre Alembic et SQLModel (create_db_and_tables()`) quand on créé notre base de données en locale.

- SQLModel avec sa fonction créer les tables quand on lancé le serveur
- Alembic quand on lancer les migrations créait aussi les tables

Pour rester logique on a fait le choix de rester sur la logique Alembic car c'est ce qui doit le plus se rapprocher de ce qui va se passer en base de données (modifications, etc).